### PR TITLE
fix parsing error on purgecss extractor code

### DIFF
--- a/_posts/2018-06-25-how-i-dropped-250-kb-of-dead-css-weight-with-purgecss.md
+++ b/_posts/2018-06-25-how-i-dropped-250-kb-of-dead-css-weight-with-purgecss.md
@@ -126,11 +126,11 @@ module.exports = {
     {
       extractor: class {
         static extract(content) {
-          return content.match(/[A-z0-9-:\/]+/g) || []
-        },
-        extensions: ['js']
-      }
-    }
+          return content.match(/[A-z0-9-:\/]+/g) || [];
+        }
+      },
+      extensions: ['js']
+    },
   ]
 }
 {% endhighlight %}


### PR DESCRIPTION
There is only one change in here.

- There was a little scope error in [How I Dropped 250 KB of Dead CSS Weight with PurgeCSS](https://frontstuff.io/how-i-dropped-250-kb-of-dead-css-weight-with-purgecss) post. `class` scope was opened but wasn't closed at the end. This PR fixes that.